### PR TITLE
Containerized arm64 cython --gdb work around

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.63)
-AC_INIT([numsos], 1.1.1, tom@ogc.us)
+AC_INIT([numsos], 1.1.1, tom@ogc.us, nick@ogc.us)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR(config)
 AM_CONFIG_HEADER(config.h)

--- a/graf_analysis/compMinMeanMax.py
+++ b/graf_analysis/compMinMeanMax.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from builtins import str
 import os, sys, traceback
 import datetime as dt
 from graf_analysis.grafanaAnalysis import Analysis
@@ -13,67 +11,35 @@ import time
 
 class compMinMeanMax(Analysis):
     def __init__(self, cont, start, end, schema='meminfo', maxDataPoints=4096):
-        self.schema = schema
-        self.src = SosDataSource()
-        self.src.config(cont=cont)
-        self.start = start
-        self.end = end
-        self.maxDataPoints = maxDataPoints
+        super().__init__(cont, start, end, schema, maxDataPoints)
 
-    def get_data(self, metric, job_id, user_id=0, params=None):
-        metric = metric[0]
-        if job_id == 0:
-            return [ { 'target' : 'Error: Please specify valid job_id', 'datapoints' : [] } ]
-        # Get components with data during given time range
-        self.src.select(['component_id'],
-                   from_ = [ self.schema ],
-                   where = [
-                       [ 'job_id', Sos.COND_EQ, job_id ],
-                       [ 'timestamp', Sos.COND_GE, self.start - 300 ],
-                       [ 'timestamp', Sos.COND_LE, self.end + 300]
-                   ],
-                   order_by = 'job_time_comp'
-            )
-        comps = self.src.get_results(limit=self.maxDataPoints)
-        if not comps:
-            return [ { 'target' : 'Error: component_id not found for Job '+str(job_id),
-                       'datapoints' : [] } ]
-        else:
-            compIds = np.unique(comps['component_id'].tolist())
-        print(compIds)
-        result = []
-        datapoints = []
-        time_range = self.end - self.start
-        if time_range > 4096:
-            bin_width = int(time_range // 200)
-        else:
-            bin_width = 1
-        dfs = []
-        for comp_id in compIds:
-            where_ = [
-                [ 'component_id', Sos.COND_EQ, comp_id ],
-                [ 'job_id', Sos.COND_EQ, job_id ],
-                [ 'timestamp', Sos.COND_GE, self.start ],
-                [ 'timestamp', Sos.COND_LE, self.end ]
-            ]
-            self.src.select([ metric, 'timestamp' ],
-                       from_ = [ self.schema ],
-                       where = where_,
-                       order_by = 'job_comp_time'
-                )
-            # default for now is dataframe - will update with dataset vs dataframe option
-            res = self.src.get_df(limit=self.maxDataPoints, index='timestamp')
+    def get_data(self, metrics, filters=[]):
+        metric = metrics[0]
+        select_clause = "select " + ",".join(metrics) + " from " + str(self.schema)
+        self.start = float(self.start)
+        self.end = float(self.end)
+        where_clause = self.get_where(filters)
+ 
+        try:
+            self.query.select(f'{select_clause} {where_clause}')
+            res = self.query.next()
             if res is None:
-                continue
-            rs = res.resample(str(bin_width)+'S').fillna("backfill")
-            dfs.append(rs)
-        df = pd.concat(dfs, axis=1, ignore_index=True)
-        res_ = DataSet()
-        min_datapoints = df.min(axis=1, skipna=True)
-        mean_datapoints = df.mean(axis=1, skipna=True)
-        max_datapoints = df.max(axis=1, skipna=True)
-        res_ = pd.DataFrame({ "min_"+metric  : min_datapoints.values,
-                              "mean_"+metric : mean_datapoints.values,
-                              "max_"+metric  : max_datapoints.values,
-                              "timestamp"    : min_datapoints.index })
-        return res_
+                return None
+            df = res.copy(deep=True)
+            while res is not None:
+                ds = 15
+                df['time_downsample'] = df['timestamp'].astype('int')/1e9
+                df['time_downsample'] = df['time_downsample'].astype('int')%ds
+                df = df[df['time_downsample'] == 0]
+                df = df.drop(['time_downsample'],axis=1)
+                df['timestamp'] = df['timestamp'].astype(int) / 1e9
+                res = self.query.next()
+                df = pd.concat([df, res])
+            ret = pd.DataFrame(pd.unique(df['timestamp'].astype(int)*1000), columns=['timestamp'])
+            ret['min'] = df.groupby(by=['timestamp'])[metric].min().reset_index()[metric]
+            ret['mean'] = df.groupby(by=['timestamp'])[metric].mean().reset_index()[metric]
+            ret['max'] = df.groupby(by=['timestamp'])[metric].max().reset_index()[metric]
+            return ret
+        except Exception as e:
+            a, b, c = sys.exc_info()
+            print(str(e)+' '+str(c.tb_lineno))

--- a/graf_analysis/compMinMeanMax.py
+++ b/graf_analysis/compMinMeanMax.py
@@ -13,32 +13,30 @@ class compMinMeanMax(Analysis):
     def __init__(self, cont, start, end, schema='meminfo', maxDataPoints=4096):
         super().__init__(cont, start, end, schema, maxDataPoints)
 
-    def get_data(self, metrics, filters=[]):
-        metric = metrics[0]
-        select_clause = "select " + ",".join(metrics) + " from " + str(self.schema)
-        self.start = float(self.start)
-        self.end = float(self.end)
+    def get_data(self, metrics, filters=[], params=None):
+        select = self.select_clause(metrics)
         where_clause = self.get_where(filters)
  
         try:
-            self.query.select(f'{select_clause} {where_clause}')
+            self.query.select(f'{select} {where_clause}')
             res = self.query.next()
             if res is None:
                 return None
             df = res.copy(deep=True)
             while res is not None:
-                ds = 15
-                df['time_downsample'] = df['timestamp'].astype('int')/1e9
-                df['time_downsample'] = df['time_downsample'].astype('int')%ds
-                df = df[df['time_downsample'] == 0]
-                df = df.drop(['time_downsample'],axis=1)
-                df['timestamp'] = df['timestamp'].astype(int) / 1e9
                 res = self.query.next()
                 df = pd.concat([df, res])
-            ret = pd.DataFrame(pd.unique(df['timestamp'].astype(int)*1000), columns=['timestamp'])
-            ret['min'] = df.groupby(by=['timestamp'])[metric].min().reset_index()[metric]
-            ret['mean'] = df.groupby(by=['timestamp'])[metric].mean().reset_index()[metric]
-            ret['max'] = df.groupby(by=['timestamp'])[metric].max().reset_index()[metric]
+            ds = 15
+            df['time_downsample'] = df['timestamp'].astype('int')/1e9
+            df['time_downsample'] = df['time_downsample'].astype('int')%ds
+            df = df[df['time_downsample'] == 0]
+            df = df.drop(['time_downsample'],axis=1)
+            df['timestamp'] = df['timestamp'].astype(int) / 1e6
+            ret = pd.DataFrame(pd.unique(df['timestamp'].astype(int)), columns=['timestamp'])
+            for metric in metrics:
+                ret[f'{metric}_min'] = df.groupby(by=['timestamp'])[metric].min().reset_index()[metric]
+                ret[f'{metric}_mean'] = df.groupby(by=['timestamp'])[metric].mean().reset_index()[metric]
+                ret[f'{metric}_max'] = df.groupby(by=['timestamp'])[metric].max().reset_index()[metric]
             return ret
         except Exception as e:
             a, b, c = sys.exc_info()

--- a/graf_analysis/grafanaAnalysis.py
+++ b/graf_analysis/grafanaAnalysis.py
@@ -48,8 +48,22 @@ class Analysis(object):
         self.schema = schema
         self.start = float(start)
         self.end = float(end)
-        self.query = Sos.SqlQuery(cont, 1000)
+        self.query = Sos.SqlQuery(cont, maxDataPoints)
         self.mdp = maxDataPoints
+
+    def get_all_data(self, query):
+        df = query.next()
+        if df is None:
+           return None
+        res = df.copy(deep=True)
+        while df is not None:
+            df = query.next()
+            res = pd.concat([df, res])
+        return res
+
+    def select_clause(self, metrics):
+        select = f'select {",".join(metrics)} from {self.schema}'
+        return select
 
     def get_where(self, filters):
         where_clause = f'where (timestamp > {self.start}) and (timestamp < {self.end})'

--- a/graf_analysis/grafanaAnalysis.py
+++ b/graf_analysis/grafanaAnalysis.py
@@ -1,4 +1,3 @@
-import traceback
 from django.db import models
 import datetime as dt
 import time
@@ -47,11 +46,16 @@ class Analysis(object):
     def __init__(self, cont, start, end, schema=None, maxDataPoints=4096):
         self.cont = cont
         self.schema = schema
-        self.start = start
-        self.end = end
-        self.src = SosDataSource()
-        self.src.config(cont=self.cont)
+        self.start = float(start)
+        self.end = float(end)
+        self.query = Sos.SqlQuery(cont, 1000)
         self.mdp = maxDataPoints
+
+    def get_where(self, filters):
+        where_clause = f'where (timestamp > {self.start}) and (timestamp < {self.end})'
+        for filt in filters:
+            where_clause += f' and ({filt})'
+        return where_clause
 
     def parse_params(self, params):
         if params is None:

--- a/graf_analysis/metricRateBin.py
+++ b/graf_analysis/metricRateBin.py
@@ -1,88 +1,56 @@
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import next
-from builtins import str
 import os, sys, traceback
 import datetime as dt
 from graf_analysis.grafanaAnalysis import Analysis
-from numsos.DataSource import SosDataSource
-from numsos.Transform import Transform
-from sosdb.DataSet import DataSet
 from sosdb import Sos
 import pandas as pd
 import numpy as np
 
 class metricRateBin(Analysis):
     def __init__(self, cont, start, end, schema='Lustre_Client', maxDataPoints=4096):
-        self.schema = schema
-        self.src = SosDataSource()
-        self.src.config(cont=cont)
-        self.start = start
-        self.end = end
-        self.mdp = maxDataPoints
+        super().__init__(cont, start, end, schema, maxDataPoints)
 
-    def get_data(self, metrics, job_id=0, user_id=0, params='bins=10'):
+    def get_data(self, metrics, filters=[], params='bins=10'):
+        select = self.select_clause(metrics)
+        where_clause = self.get_where(filters)
         self.bins = 10
         result = []
         datapoints = []
         time_range = self.end - self.start
-        offset = time_range * .01
-        if offset < 1:
-            offset = 1
-        where_ = [ [ 'timestamp', Sos.COND_GE, self.start - offset ],
-                   [ 'timestamp', Sos.COND_LE, self.end + offset ]
-            ]
-        if job_id > 0:
-            where_.append(['job_id', Sos.COND_EQ, job_id])
         try:
-            self.src.select(metrics + ['timestamp','component_id' ],
-                       from_ = [ self.schema ],
-                       where = where_,
-                       order_by = 'time_comp_job'
-                )
-            inp = None
+            self.query.select(f'{select} {where_clause}')
 
             # default for now is dataframe - will update with dataset vs dataframe option
-            self.xfrm = Transform(self.src, None, limit=self.mdp)
-            resp = self.xfrm.begin()
-            if resp is None:
-                print('resp == None')
+            df = self.query.next()
+            if df is None:
                 return None
-
-            while resp is not None:
-                resp = next(self.xfrm)
-                if resp is not None:
-                    self.xfrm.concat()
-            self.xfrm.dup()
-            data = self.xfrm.pop()
-
-            self.xfrm.diff(metrics, group_name="component_id",
-                           keep=['timestamp'], xfrm_suffix='')
-
-            data = self.xfrm.pop()
-            hsum = None
-            data_time = (data.array('timestamp')[-1].astype('float') - data.array('timestamp')[0].astype('float'))
-            data_time = data_time / 1000000
+            df = df[~df.index.duplicated(keep='first')]
+            tstamps = df['timestamp'].astype('int') / 1e6
+            df = df.drop('timestamp', axis=1)
+            data_time = tstamps[-1] - tstamps[0]
             if data_time < time_range:
                 bins = int(data_time / time_range * 20)
                 if bins < 2:
                     bins = 2
             else:
-                bins = 20 
-            for met_diff in metrics:
-                os = data.array(met_diff)
-                
-                h = np.histogram(data.array('timestamp').astype('float'), bins=bins,
+                bins = 20
+            dff = df.groupby(['component_id']).diff().fillna(0)
+            hsum = None
+            metric_str = ''
+            for metric in metrics:
+                if len(metric_str) > 0:
+                    metric_str += ', '
+                metric_str += metric
+                os = dff[metric]
+                h = np.histogram(tstamps, bins=bins,
                                  weights=os, density=False)
                 if hsum is None:
-                    ts = h[1][:-1] / 1000
+                    ts = h[1][:-1]
                     hsum = np.zeros(h[0].shape)
                 hsum += h[0]
-            res = DataSet()
-            res.append_array(len(hsum), str(metrics), hsum)
-            res.append_array(len(ts), 'timestamp', ts) 
-            return res 
+            ret = pd.DataFrame(ts, columns=['timestamp'])
+            ret.insert(0, f'{metric_str} Rate', hsum, True)
+            
+            return ret
         except Exception as e:
             a, b, c = sys.exc_info()
             print(str(e)+' '+str(c.tb_lineno))

--- a/m4/ac_python_devel.m4
+++ b/m4/ac_python_devel.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#      http://www.gnu.org/software/autoconf-archive/ax_python_devel.html
+#     https://www.gnu.org/software/autoconf-archive/ax_python_devel.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -12,8 +12,8 @@
 #   in your configure.ac.
 #
 #   This macro checks for Python and tries to get the include path to
-#   'Python.h'. It provides the $(PYTHON_CPPFLAGS) and $(PYTHON_LDFLAGS)
-#   output variables. It also exports $(PYTHON_EXTRA_LIBS) and
+#   'Python.h'. It provides the $(PYTHON_CPPFLAGS) and $(PYTHON_LIBS) output
+#   variables. It also exports $(PYTHON_EXTRA_LIBS) and
 #   $(PYTHON_EXTRA_LDFLAGS) for embedding Python in your code.
 #
 #   You can search for some particular version of Python by passing a
@@ -52,7 +52,7 @@
 #   Public License for more details.
 #
 #   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 #   As a special exception, the respective Autoconf Macro's copyright owner
 #   gives unlimited permission to copy, distribute and modify the configure
@@ -67,7 +67,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 16
+#serial 25
 
 AU_ALIAS([AC_PYTHON_DEVEL], [AX_PYTHON_DEVEL])
 AC_DEFUN([AX_PYTHON_DEVEL],[
@@ -99,7 +99,7 @@ AC_DEFUN([AX_PYTHON_DEVEL],[
 This version of the AC@&t@_PYTHON_DEVEL macro
 doesn't work properly with versions of Python before
 2.1.0. You may need to re-run configure, setting the
-variables PYTHON_CPPFLAGS, PYTHON_LDFLAGS, PYTHON_SITE_PKG,
+variables PYTHON_CPPFLAGS, PYTHON_LIBS, PYTHON_SITE_PKG,
 PYTHON_EXTRA_LIBS and PYTHON_EXTRA_LDFLAGS by hand.
 Moreover, to disable this check, set PYTHON_NOVERSIONCHECK
 to something else than an empty string.
@@ -112,15 +112,39 @@ to something else than an empty string.
 	fi
 
 	#
-	# if the macro parameter ``version'' is set, honour it
+	# If the macro parameter ``version'' is set, honour it.
+	# A Python shim class, VPy, is used to implement correct version comparisons via
+	# string expressions, since e.g. a naive textual ">= 2.7.3" won't work for
+	# Python 2.7.10 (the ".1" being evaluated as less than ".3").
 	#
 	if test -n "$1"; then
 		AC_MSG_CHECKING([for a version of Python $1])
-		ac_supports_python_ver=`$PYTHON -c "import sys; \
-			ver = sys.version.split ()[[0]]; \
+                cat << EOF > ax_python_devel_vpy.py
+class VPy:
+    def vtup(self, s):
+        return tuple(map(int, s.strip().replace("rc", ".").split(".")))
+    def __init__(self):
+        import sys
+        self.vpy = tuple(sys.version_info)
+    def __eq__(self, s):
+        return self.vpy == self.vtup(s)
+    def __ne__(self, s):
+        return self.vpy != self.vtup(s)
+    def __lt__(self, s):
+        return self.vpy < self.vtup(s)
+    def __gt__(self, s):
+        return self.vpy > self.vtup(s)
+    def __le__(self, s):
+        return self.vpy <= self.vtup(s)
+    def __ge__(self, s):
+        return self.vpy >= self.vtup(s)
+EOF
+		ac_supports_python_ver=`$PYTHON -c "import ax_python_devel_vpy; \
+                        ver = ax_python_devel_vpy.VPy(); \
 			print (ver $1)"`
+                rm -rf ax_python_devel_vpy*.py* __pycache__/ax_python_devel_vpy*.py*
 		if test "$ac_supports_python_ver" = "True"; then
-		   AC_MSG_RESULT([yes])
+			AC_MSG_RESULT([yes])
 		else
 			AC_MSG_RESULT([no])
 			AC_MSG_ERROR([this package requires Python $1.
@@ -135,16 +159,25 @@ variable to configure. See ``configure --help'' for reference.
 	#
 	# Check if you have distutils, else fail
 	#
-	AC_MSG_CHECKING([for the distutils Python package])
-	ac_distutils_result=`$PYTHON -c "import distutils" 2>&1`
-	if test -z "$ac_distutils_result"; then
+	AC_MSG_CHECKING([for the sysconfig Python package])
+	ac_sysconfig_result=`$PYTHON -c "import sysconfig" 2>&1`
+	if test $? -eq 0; then
 		AC_MSG_RESULT([yes])
+		IMPORT_SYSCONFIG="import sysconfig"
 	else
 		AC_MSG_RESULT([no])
-		AC_MSG_ERROR([cannot import Python module "distutils".
+
+		AC_MSG_CHECKING([for the distutils Python package])
+		ac_sysconfig_result=`$PYTHON -c "from distutils import sysconfig" 2>&1`
+		if test $? -eq 0; then
+			AC_MSG_RESULT([yes])
+			IMPORT_SYSCONFIG="from distutils import sysconfig"
+		else
+			AC_MSG_ERROR([cannot import Python module "distutils".
 Please check your Python installation. The error was:
-$ac_distutils_result])
-		PYTHON_VERSION=""
+$ac_sysconfig_result])
+			PYTHON_VERSION=""
+		fi
 	fi
 
 	#
@@ -152,10 +185,19 @@ $ac_distutils_result])
 	#
 	AC_MSG_CHECKING([for Python include path])
 	if test -z "$PYTHON_CPPFLAGS"; then
-		python_path=`$PYTHON -c "import distutils.sysconfig; \
-			print (distutils.sysconfig.get_python_inc ());"`
-		plat_python_path=`$PYTHON -c "import distutils.sysconfig; \
-			print (distutils.sysconfig.get_python_inc (plat_specific=1));"`
+		if test "$IMPORT_SYSCONFIG" = "import sysconfig"; then
+			# sysconfig module has different functions
+			python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_path ('include'));"`
+			plat_python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_path ('platinclude'));"`
+		else
+			# old distutils way
+			python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_python_inc ());"`
+			plat_python_path=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_python_inc (plat_specific=1));"`
+		fi
 		if test -n "${python_path}"; then
 			if test "${plat_python_path}" != "${python_path}"; then
 				python_path="-I$python_path -I$plat_python_path"
@@ -172,14 +214,14 @@ $ac_distutils_result])
 	# Check for Python library path
 	#
 	AC_MSG_CHECKING([for Python library path])
-	if test -z "$PYTHON_LDFLAGS"; then
+	if test -z "$PYTHON_LIBS"; then
 		# (makes two attempts to ensure we've got a version number
 		# from the interpreter)
 		ac_python_version=`cat<<EOD | $PYTHON -
 
 # join all versioning strings, on some systems
 # major/minor numbers could be in different list elements
-from distutils.sysconfig import *
+from sysconfig import *
 e = get_config_var('VERSION')
 if e is not None:
 	print(e)
@@ -202,8 +244,8 @@ EOD`
 		ac_python_libdir=`cat<<EOD | $PYTHON -
 
 # There should be only one
-import distutils.sysconfig
-e = distutils.sysconfig.get_config_var('LIBDIR')
+$IMPORT_SYSCONFIG
+e = sysconfig.get_config_var('LIBDIR')
 if e is not None:
 	print (e)
 EOD`
@@ -211,8 +253,8 @@ EOD`
 		# Now, for the library:
 		ac_python_library=`cat<<EOD | $PYTHON -
 
-import distutils.sysconfig
-c = distutils.sysconfig.get_config_vars()
+$IMPORT_SYSCONFIG
+c = sysconfig.get_config_vars()
 if 'LDVERSION' in c:
 	print ('python'+c[['LDVERSION']])
 else:
@@ -227,45 +269,68 @@ EOD`
 		then
 			# use the official shared library
 			ac_python_library=`echo "$ac_python_library" | sed "s/^lib//"`
-			PYTHON_LDFLAGS="-L$ac_python_libdir -l$ac_python_library"
+			PYTHON_LIBS="-L$ac_python_libdir -l$ac_python_library"
 		else
 			# old way: use libpython from python_configdir
 			ac_python_libdir=`$PYTHON -c \
-			  "from distutils.sysconfig import get_python_lib as f; \
+			  "from sysconfig import get_python_lib as f; \
 			  import os; \
 			  print (os.path.join(f(plat_specific=1, standard_lib=1), 'config'));"`
-			PYTHON_LDFLAGS="-L$ac_python_libdir -lpython$ac_python_version"
+			PYTHON_LIBS="-L$ac_python_libdir -lpython$ac_python_version"
 		fi
 
-		if test -z "PYTHON_LDFLAGS"; then
+		if test -z "PYTHON_LIBS"; then
 			AC_MSG_ERROR([
   Cannot determine location of your Python DSO. Please check it was installed with
-  dynamic libraries enabled, or try setting PYTHON_LDFLAGS by hand.
+  dynamic libraries enabled, or try setting PYTHON_LIBS by hand.
 			])
 		fi
 	fi
-	AC_MSG_RESULT([$PYTHON_LDFLAGS])
-	AC_SUBST([PYTHON_LDFLAGS])
+	AC_MSG_RESULT([$PYTHON_LIBS])
+	AC_SUBST([PYTHON_LIBS])
 
 	#
 	# Check for site packages
 	#
 	AC_MSG_CHECKING([for Python site-packages path])
 	if test -z "$PYTHON_SITE_PKG"; then
-		PYTHON_SITE_PKG=`$PYTHON -c "import distutils.sysconfig; \
-			print (distutils.sysconfig.get_python_lib(0,0));"`
+		if test "$IMPORT_SYSCONFIG" = "import sysconfig"; then
+			PYTHON_SITE_PKG=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_path('purelib'));"`
+		else
+			# distutils.sysconfig way
+			PYTHON_SITE_PKG=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_python_lib(0,0));"`
+		fi
 	fi
 	AC_MSG_RESULT([$PYTHON_SITE_PKG])
 	AC_SUBST([PYTHON_SITE_PKG])
+
+	#
+	# Check for platform-specific site packages
+	#
+	AC_MSG_CHECKING([for Python platform specific site-packages path])
+	if test -z "$PYTHON_SITE_PKG"; then
+		if test "$IMPORT_SYSCONFIG" = "import sysconfig"; then
+			PYTHON_PLATFORM_SITE_PKG=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_path('platlib'));"`
+		else
+			# distutils.sysconfig way
+			PYTHON_PLATFORM_SITE_PKG=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+				print (sysconfig.get_python_lib(1,0));"`
+		fi
+	fi
+	AC_MSG_RESULT([$PYTHON_PLATFORM_SITE_PKG])
+	AC_SUBST([PYTHON_PLATFORM_SITE_PKG])
 
 	#
 	# libraries which must be linked in when embedding
 	#
 	AC_MSG_CHECKING(python extra libraries)
 	if test -z "$PYTHON_EXTRA_LIBS"; then
-	   PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
-                conf = distutils.sysconfig.get_config_var; \
-                print (conf('LIBS'))"`
+	   PYTHON_EXTRA_LIBS=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+                conf = sysconfig.get_config_var; \
+                print (conf('LIBS') + ' ' + conf('SYSLIBS'))"`
 	fi
 	AC_MSG_RESULT([$PYTHON_EXTRA_LIBS])
 	AC_SUBST(PYTHON_EXTRA_LIBS)
@@ -275,8 +340,8 @@ EOD`
 	#
 	AC_MSG_CHECKING(python extra linking flags)
 	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
-		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import distutils.sysconfig; \
-			conf = distutils.sysconfig.get_config_var; \
+		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "$IMPORT_SYSCONFIG; \
+			conf = sysconfig.get_config_var; \
 			print (conf('LINKFORSHARED'))"`
 	fi
 	AC_MSG_RESULT([$PYTHON_EXTRA_LDFLAGS])
@@ -288,8 +353,10 @@ EOD`
 	AC_MSG_CHECKING([consistency of all components of python development environment])
 	# save current global flags
 	ac_save_LIBS="$LIBS"
+	ac_save_LDFLAGS="$LDFLAGS"
 	ac_save_CPPFLAGS="$CPPFLAGS"
-	LIBS="$ac_save_LIBS $PYTHON_LDFLAGS $PYTHON_EXTRA_LDFLAGS $PYTHON_EXTRA_LIBS"
+	LIBS="$ac_save_LIBS $PYTHON_LIBS $PYTHON_EXTRA_LIBS $PYTHON_EXTRA_LIBS"
+	LDFLAGS="$ac_save_LDFLAGS $PYTHON_EXTRA_LDFLAGS"
 	CPPFLAGS="$ac_save_CPPFLAGS $PYTHON_CPPFLAGS"
 	AC_LANG_PUSH([C])
 	AC_LINK_IFELSE([
@@ -300,6 +367,7 @@ EOD`
 	# turn back to default flags
 	CPPFLAGS="$ac_save_CPPFLAGS"
 	LIBS="$ac_save_LIBS"
+	LDFLAGS="$ac_save_LDFLAGS"
 
 	AC_MSG_RESULT([$pythonexists])
 
@@ -307,8 +375,8 @@ EOD`
 	   AC_MSG_FAILURE([
   Could not link test program to Python. Maybe the main Python library has been
   installed in some non-standard library path. If so, pass it to configure,
-  via the LDFLAGS environment variable.
-  Example: ./configure LDFLAGS="-L/usr/non-standard-path/python/lib"
+  via the LIBS environment variable.
+  Example: ./configure LIBS="-L/usr/non-standard-path/python/lib"
   ============================================================================
    ERROR!
    You probably have to install the development version of the Python package

--- a/m4/python.m4
+++ b/m4/python.m4
@@ -1,14 +1,14 @@
 ## ------------------------                                 -*- Autoconf -*-
 ## Python file handling
 ## From Andrew Dalke
-## Updated by James Henstridge
+## Updated by James Henstridge and other contributors.
 ## ------------------------
-# Copyright (C) 1999, 2000, 2001, 2002, 2003, 2004, 2005
-# Free Software Foundation, Inc.
+# Copyright (C) 1999-2021 Free Software Foundation, Inc.
 #
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
 # with or without modifications, as long as this notice is preserved.
+
 
 # AM_PATH_PYTHON([MINIMUM-VERSION], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
 # ---------------------------------------------------------------------------
@@ -34,13 +34,17 @@
 # numbers and dots only.
 AC_DEFUN([AM_PATH_PYTHON],
  [
-  dnl Find a Python interpreter.  Python versions prior to 1.5 are not
-  dnl supported because the default installation locations changed from
-  dnl $prefix/lib/site-python in 1.4 to $prefix/lib/python1.5/site-packages
-  dnl in 1.5.
+  dnl Find a Python interpreter.  Python versions prior to 2.0 are not
+  dnl supported. (2.0 was released on October 16, 2000).
   m4_define_default([_AM_PYTHON_INTERPRETER_LIST],
-                    [python python2 python2.5 python2.4 python2.3 python2.2 dnl
-python2.1 python2.0 python1.6 python1.5])
+[python python2 python3 dnl
+ python3.11 python3.10 dnl
+ python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 dnl
+ python3.2 python3.1 python3.0 dnl
+ python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 dnl
+ python2.0])
+
+  AC_ARG_VAR([PYTHON], [the Python interpreter])
 
   m4_if([$1],[],[
     dnl No version check is needed.
@@ -53,10 +57,11 @@ python2.1 python2.0 python1.6 python1.5])
     dnl A version check is needed.
     if test -n "$PYTHON"; then
       # If the user set $PYTHON, use it and don't search something else.
-      AC_MSG_CHECKING([whether $PYTHON version >= $1])
+      AC_MSG_CHECKING([whether $PYTHON version is >= $1])
       AM_PYTHON_CHECK_VERSION([$PYTHON], [$1],
-			      [AC_MSG_RESULT(yes)],
-			      [AC_MSG_ERROR(too old)])
+			      [AC_MSG_RESULT([yes])],
+			      [AC_MSG_RESULT([no])
+			       AC_MSG_ERROR([Python interpreter is too old])])
       am_display_PYTHON=$PYTHON
     else
       # Otherwise, try each interpreter until we find one that satisfies
@@ -78,74 +83,263 @@ python2.1 python2.0 python1.6 python1.5])
   ])
 
   if test "$PYTHON" = :; then
-  dnl Run any user-specified action, or abort.
+    dnl Run any user-specified action, or abort.
     m4_default([$3], [AC_MSG_ERROR([no suitable Python interpreter found])])
   else
 
-  dnl Query Python for its version number.  Getting [:3] seems to be
-  dnl the best way to do this; it's what "site.py" does in the standard
-  dnl library.
-
+  dnl Query Python for its version number.  Although site.py simply uses
+  dnl sys.version[:3], printing that failed with Python 3.10, since the
+  dnl trailing zero was eliminated. So now we output just the major
+  dnl and minor version numbers, as numbers. Apparently the tertiary
+  dnl version is not of interest.
+  dnl
   AC_CACHE_CHECK([for $am_display_PYTHON version], [am_cv_python_version],
-    [am_cv_python_version=`$PYTHON -c "import sys; print (sys.version[[:3]])"`])
+    [am_cv_python_version=`$PYTHON -c "import sys; print ('%u.%u' % sys.version_info[[:2]])"`])
   AC_SUBST([PYTHON_VERSION], [$am_cv_python_version])
 
-  dnl Use the values of $prefix and $exec_prefix for the corresponding
-  dnl values of PYTHON_PREFIX and PYTHON_EXEC_PREFIX.  These are made
-  dnl distinct variables so they can be overridden if need be.  However,
-  dnl general consensus is that you shouldn't need this ability.
-
-  AC_SUBST([PYTHON_PREFIX], ['${prefix}'])
-  AC_SUBST([PYTHON_EXEC_PREFIX], ['${exec_prefix}'])
-
-  dnl At times (like when building shared libraries) you may want
+  dnl At times, e.g., when building shared libraries, you may want
   dnl to know which OS platform Python thinks this is.
-
+  dnl
   AC_CACHE_CHECK([for $am_display_PYTHON platform], [am_cv_python_platform],
-    [am_cv_python_platform=`$PYTHON -c "import sys; print (sys.platform)"`])
+    [am_cv_python_platform=`$PYTHON -c "import sys; sys.stdout.write(sys.platform)"`])
   AC_SUBST([PYTHON_PLATFORM], [$am_cv_python_platform])
 
+  dnl emacs-page
+  dnl If --with-python-sys-prefix is given, use the values of sys.prefix
+  dnl and sys.exec_prefix for the corresponding values of PYTHON_PREFIX
+  dnl and PYTHON_EXEC_PREFIX. Otherwise, use the GNU ${prefix} and
+  dnl ${exec_prefix} variables.
+  dnl
+  dnl The two are made distinct variables so they can be overridden if
+  dnl need be, although general consensus is that you shouldn't need
+  dnl this separation.
+  dnl
+  dnl Also allow directly setting the prefixes via configure options,
+  dnl overriding any default.
+  dnl
+  if test "x$prefix" = xNONE; then
+    am__usable_prefix=$ac_default_prefix
+  else
+    am__usable_prefix=$prefix
+  fi
 
-  dnl Set up 4 directories:
+  # Allow user to request using sys.* values from Python,
+  # instead of the GNU $prefix values.
+  AC_ARG_WITH([python-sys-prefix],
+  [AS_HELP_STRING([--with-python-sys-prefix],
+                  [use Python's sys.prefix and sys.exec_prefix values])],
+  [am_use_python_sys=:],
+  [am_use_python_sys=false])
 
-  dnl pythondir -- where to install python scripts.  This is the
-  dnl   site-packages directory, not the python standard library
-  dnl   directory like in previous automake betas.  This behavior
-  dnl   is more consistent with lispdir.m4 for example.
-  dnl Query distutils for this directory.  distutils does not exist in
-  dnl Python 1.5, so we fall back to the hardcoded directory if it
-  dnl doesn't work.
-  AC_CACHE_CHECK([for $am_display_PYTHON script directory],
-    [am_cv_python_pythondir],
-    [am_cv_python_pythondir=`$PYTHON -c "from distutils import sysconfig; print (sysconfig.get_python_lib(0,0,prefix='$PYTHON_PREFIX'))" 2>/dev/null ||
-     echo "$PYTHON_PREFIX/lib/python$PYTHON_VERSION/site-packages"`])
+  # Allow user to override whatever the default Python prefix is.
+  AC_ARG_WITH([python_prefix],
+  [AS_HELP_STRING([--with-python_prefix],
+                  [override the default PYTHON_PREFIX])],
+  [am_python_prefix_subst=$withval
+   am_cv_python_prefix=$withval
+   AC_MSG_CHECKING([for explicit $am_display_PYTHON prefix])
+   AC_MSG_RESULT([$am_cv_python_prefix])],
+  [
+   if $am_use_python_sys; then
+     # using python sys.prefix value, not GNU
+     AC_CACHE_CHECK([for python default $am_display_PYTHON prefix],
+     [am_cv_python_prefix],
+     [am_cv_python_prefix=`$PYTHON -c "import sys; sys.stdout.write(sys.prefix)"`])
+
+     dnl If sys.prefix is a subdir of $prefix, replace the literal value of
+     dnl $prefix with a variable reference so it can be overridden.
+     case $am_cv_python_prefix in
+     $am__usable_prefix*)
+       am__strip_prefix=`echo "$am__usable_prefix" | sed 's|.|.|g'`
+       am_python_prefix_subst=`echo "$am_cv_python_prefix" | sed "s,^$am__strip_prefix,\\${prefix},"`
+       ;;
+     *)
+       am_python_prefix_subst=$am_cv_python_prefix
+       ;;
+     esac
+   else # using GNU prefix value, not python sys.prefix
+     am_python_prefix_subst='${prefix}'
+     am_python_prefix=$am_python_prefix_subst
+     AC_MSG_CHECKING([for GNU default $am_display_PYTHON prefix])
+     AC_MSG_RESULT([$am_python_prefix])
+   fi])
+  # Substituting python_prefix_subst value.
+  AC_SUBST([PYTHON_PREFIX], [$am_python_prefix_subst])
+
+  # emacs-page Now do it all over again for Python exec_prefix, but with yet
+  # another conditional: fall back to regular prefix if that was specified.
+  AC_ARG_WITH([python_exec_prefix],
+  [AS_HELP_STRING([--with-python_exec_prefix],
+                  [override the default PYTHON_EXEC_PREFIX])],
+  [am_python_exec_prefix_subst=$withval
+   am_cv_python_exec_prefix=$withval
+   AC_MSG_CHECKING([for explicit $am_display_PYTHON exec_prefix])
+   AC_MSG_RESULT([$am_cv_python_exec_prefix])],
+  [
+   # no explicit --with-python_exec_prefix, but if
+   # --with-python_prefix was given, use its value for python_exec_prefix too.
+   AS_IF([test -n "$with_python_prefix"],
+   [am_python_exec_prefix_subst=$with_python_prefix
+    am_cv_python_exec_prefix=$with_python_prefix
+    AC_MSG_CHECKING([for python_prefix-given $am_display_PYTHON exec_prefix])
+    AC_MSG_RESULT([$am_cv_python_exec_prefix])],
+   [
+    # Set am__usable_exec_prefix whether using GNU or Python values,
+    # since we use that variable for pyexecdir.
+    if test "x$exec_prefix" = xNONE; then
+      am__usable_exec_prefix=$am__usable_prefix
+    else
+      am__usable_exec_prefix=$exec_prefix
+    fi
+    #
+    if $am_use_python_sys; then # using python sys.exec_prefix, not GNU
+      AC_CACHE_CHECK([for python default $am_display_PYTHON exec_prefix],
+      [am_cv_python_exec_prefix],
+      [am_cv_python_exec_prefix=`$PYTHON -c "import sys; sys.stdout.write(sys.exec_prefix)"`])
+      dnl If sys.exec_prefix is a subdir of $exec_prefix, replace the
+      dnl literal value of $exec_prefix with a variable reference so it can
+      dnl be overridden.
+      case $am_cv_python_exec_prefix in
+      $am__usable_exec_prefix*)
+        am__strip_prefix=`echo "$am__usable_exec_prefix" | sed 's|.|.|g'`
+        am_python_exec_prefix_subst=`echo "$am_cv_python_exec_prefix" | sed "s,^$am__strip_prefix,\\${exec_prefix},"`
+        ;;
+      *)
+        am_python_exec_prefix_subst=$am_cv_python_exec_prefix
+        ;;
+     esac
+   else # using GNU $exec_prefix, not python sys.exec_prefix
+     am_python_exec_prefix_subst='${exec_prefix}'
+     am_python_exec_prefix=$am_python_exec_prefix_subst
+     AC_MSG_CHECKING([for GNU default $am_display_PYTHON exec_prefix])
+     AC_MSG_RESULT([$am_python_exec_prefix])
+   fi])])
+  # Substituting python_exec_prefix_subst.
+  AC_SUBST([PYTHON_EXEC_PREFIX], [$am_python_exec_prefix_subst])
+
+  # Factor out some code duplication into this shell variable.
+  am_python_setup_sysconfig="\
+import sys
+# Prefer sysconfig over distutils.sysconfig, for better compatibility
+# with python 3.x.  See automake bug#10227.
+try:
+    import sysconfig
+except ImportError:
+    can_use_sysconfig = 0
+else:
+    can_use_sysconfig = 1
+# Can't use sysconfig in CPython 2.7, since it's broken in virtualenvs:
+# <https://github.com/pypa/virtualenv/issues/118>
+try:
+    from platform import python_implementation
+    if python_implementation() == 'CPython' and sys.version[[:3]] == '2.7':
+        can_use_sysconfig = 0
+except ImportError:
+    pass"
+
+  dnl emacs-page Set up 4 directories:
+
+  dnl 1. pythondir: where to install python scripts.  This is the
+  dnl    site-packages directory, not the python standard library
+  dnl    directory like in previous automake betas.  This behavior
+  dnl    is more consistent with lispdir.m4 for example.
+  dnl Query distutils for this directory.
+  dnl
+  AC_CACHE_CHECK([for $am_display_PYTHON script directory (pythondir)],
+  [am_cv_python_pythondir],
+  [if test "x$am_cv_python_prefix" = x; then
+     am_py_prefix=$am__usable_prefix
+   else
+     am_py_prefix=$am_cv_python_prefix
+   fi
+   am_cv_python_pythondir=`$PYTHON -c "
+$am_python_setup_sysconfig
+if can_use_sysconfig:
+  if hasattr(sysconfig, 'get_default_scheme'):
+    scheme = sysconfig.get_default_scheme()
+  else:
+    scheme = sysconfig._get_default_scheme()
+  if scheme == 'posix_local':
+    # Debian's default scheme installs to /usr/local/ but we want to find headers in /usr/
+    scheme = 'posix_prefix'
+  sitedir = sysconfig.get_path('purelib', scheme, vars={'base':'$am_py_prefix'})
+else:
+  from distutils import sysconfig
+  sitedir = sysconfig.get_python_lib(0, 0, prefix='$am_py_prefix')
+sys.stdout.write(sitedir)"`
+   #
+   case $am_cv_python_pythondir in
+   $am_py_prefix*)
+     am__strip_prefix=`echo "$am_py_prefix" | sed 's|.|.|g'`
+     am_cv_python_pythondir=`echo "$am_cv_python_pythondir" | sed "s,^$am__strip_prefix,\\${PYTHON_PREFIX},"`
+     ;;
+   *)
+     case $am_py_prefix in
+       /usr|/System*) ;;
+       *) am_cv_python_pythondir="\${PYTHON_PREFIX}/lib/python$PYTHON_VERSION/site-packages"
+          ;;
+     esac
+     ;;
+   esac
+  ])
   AC_SUBST([pythondir], [$am_cv_python_pythondir])
 
-  dnl pkgpythondir -- $PACKAGE directory under pythondir.  Was
-  dnl   PYTHON_SITE_PACKAGE in previous betas, but this naming is
-  dnl   more consistent with the rest of automake.
-
+  dnl 2. pkgpythondir: $PACKAGE directory under pythondir.  Was
+  dnl    PYTHON_SITE_PACKAGE in previous betas, but this naming is
+  dnl    more consistent with the rest of automake.
+  dnl
   AC_SUBST([pkgpythondir], [\${pythondir}/$PACKAGE])
 
-  dnl pyexecdir -- directory for installing python extension modules
-  dnl   (shared libraries)
-  dnl Query distutils for this directory.  distutils does not exist in
-  dnl Python 1.5, so we fall back to the hardcoded directory if it
-  dnl doesn't work.
-  AC_CACHE_CHECK([for $am_display_PYTHON extension module directory],
-    [am_cv_python_pyexecdir],
-    [am_cv_python_pyexecdir=`$PYTHON -c "from distutils import sysconfig; print (sysconfig.get_python_lib(1,0,prefix='$PYTHON_EXEC_PREFIX'))" 2>/dev/null ||
-     echo "${PYTHON_EXEC_PREFIX}/lib/python${PYTHON_VERSION}/site-packages"`])
+  dnl 3. pyexecdir: directory for installing python extension modules
+  dnl    (shared libraries).
+  dnl Query distutils for this directory.
+  dnl
+  AC_CACHE_CHECK([for $am_display_PYTHON extension module directory (pyexecdir)],
+  [am_cv_python_pyexecdir],
+  [if test "x$am_cv_python_exec_prefix" = x; then
+     am_py_exec_prefix=$am__usable_exec_prefix
+   else
+     am_py_exec_prefix=$am_cv_python_exec_prefix
+   fi
+   am_cv_python_pyexecdir=`$PYTHON -c "
+$am_python_setup_sysconfig
+if can_use_sysconfig:
+  if hasattr(sysconfig, 'get_default_scheme'):
+    scheme = sysconfig.get_default_scheme()
+  else:
+    scheme = sysconfig._get_default_scheme()
+  if scheme == 'posix_local':
+    # Debian's default scheme installs to /usr/local/ but we want to find headers in /usr/
+    scheme = 'posix_prefix'
+  sitedir = sysconfig.get_path('platlib', scheme, vars={'platbase':'$am_py_exec_prefix'})
+else:
+  from distutils import sysconfig
+  sitedir = sysconfig.get_python_lib(1, 0, prefix='$am_py_exec_prefix')
+sys.stdout.write(sitedir)"`
+   #
+   case $am_cv_python_pyexecdir in
+   $am_py_exec_prefix*)
+     am__strip_prefix=`echo "$am_py_exec_prefix" | sed 's|.|.|g'`
+     am_cv_python_pyexecdir=`echo "$am_cv_python_pyexecdir" | sed "s,^$am__strip_prefix,\\${PYTHON_EXEC_PREFIX},"`
+     ;;
+   *)
+     case $am_py_exec_prefix in
+       /usr|/System*) ;;
+       *) am_cv_python_pyexecdir="\${PYTHON_EXEC_PREFIX}/lib/python$PYTHON_VERSION/site-packages"
+          ;;
+     esac
+     ;;
+   esac
+  ])
   AC_SUBST([pyexecdir], [$am_cv_python_pyexecdir])
 
-  dnl pkgpyexecdir -- $(pyexecdir)/$(PACKAGE)
-
+  dnl 4. pkgpyexecdir: $(pyexecdir)/$(PACKAGE)
+  dnl
   AC_SUBST([pkgpyexecdir], [\${pyexecdir}/$PACKAGE])
 
   dnl Run any user-specified action.
   $2
   fi
-
 ])
 
 
@@ -155,14 +349,15 @@ python2.1 python2.0 python1.6 python1.5])
 # Run ACTION-IF-FALSE otherwise.
 # This test uses sys.hexversion instead of the string equivalent (first
 # word of sys.version), in order to cope with versions such as 2.2c1.
-# hexversion has been introduced in Python 1.5.2; it's probably not
-# worth to support older versions (1.5.1 was released on October 31, 1998).
+# This supports Python 2.0 or higher. (2.0 was released on October 16, 2000).
 AC_DEFUN([AM_PYTHON_CHECK_VERSION],
- [prog="import sys, string
+ [prog="import sys
 # split strings by '.' and convert to numeric.  Append some zeros
 # because we need at least 4 digits for the hex conversion.
-minver = map(int, string.split('$2', '.')) + [[0, 0, 0]]
+# map returns an iterator in Python 3.0 and a list in 2.x
+minver = list(map(int, '$2'.split('.'))) + [[0, 0, 0]]
 minverhex = 0
-for i in xrange(0, 4): minverhex = (minverhex << 8) + minver[[i]]
+# xrange is not present in Python 3.0 and range returns an iterator
+for i in list(range(0, 4)): minverhex = (minverhex << 8) + minver[[i]]
 sys.exit(sys.hexversion < minverhex)"
   AS_IF([AM_RUN_LOG([$1 -c "$prog"])], [$3], [$4])])

--- a/numsos/Makefile.am
+++ b/numsos/Makefile.am
@@ -22,7 +22,9 @@ Inputer_la_LIBADD = @SOS_LIBDIR_FLAG@ @SOS_LIB64DIR_FLAG@ -lsos
 
 pkgpyexecdir = $(pkgpythondir)
 
+CYTHON_GDB = $(shell [ "$(uname -p)" = "x86_64" ] && echo --gdb || echo "" )
+
 Inputer.c: Inputer.pyx
 	echo PYTHON_LDFLAGS are "$(PYTHON_LDFLAGS)"
-	cython -3 --directive language_level=3 --gdb $< -o $@
+	cython -3 --directive language_level=3 $(CYTHON_GDB) $< -o $@
 


### PR DESCRIPTION
cython with `--gdb` option resulted in "segmentation fault" at build
time on arm64 (aarch64) containers. This issue does not appear on x86_64
containers. This patch adds a work around to only enable `cython --gdb`
option for x86_64 architecture.