### PR TITLE
Fix compMinMeanMax bug; it returned same min,man,max values

### DIFF
--- a/graf_analysis/compMinMeanMax.py
+++ b/graf_analysis/compMinMeanMax.py
@@ -16,7 +16,7 @@ class compMinMeanMax(Analysis):
     def get_data(self, metrics, filters=[], params=None):
         select = self.select_clause(metrics)
         where_clause = self.get_where(filters)
- 
+
         try:
             self.query.select(f'{select} {where_clause}')
             res = self.query.next()
@@ -27,16 +27,20 @@ class compMinMeanMax(Analysis):
                 res = self.query.next()
                 df = pd.concat([df, res])
             ds = 15
-            df['time_downsample'] = df['timestamp'].astype('int')/1e9
+            df['time_downsample'] = (df['timestamp'].astype(int)/int(1e9)).astype(int)
             df['time_downsample'] = df['time_downsample'].astype('int')%ds
             df = df[df['time_downsample'] == 0]
             df = df.drop(['time_downsample'],axis=1)
-            df['timestamp'] = df['timestamp'].astype(int) / 1e6
+            df['timestamp'] = (df['timestamp'].astype(int)/int(1e9)).astype(int)
+            df['timestamp'] = df['timestamp'] * 1000
             ret = pd.DataFrame(pd.unique(df['timestamp'].astype(int)), columns=['timestamp'])
+            _min = df.groupby(by=['timestamp']).min().reset_index()
+            _max = df.groupby(by=['timestamp']).max().reset_index()
+            _mean = df.groupby(by=['timestamp']).mean().reset_index()
             for metric in metrics:
-                ret[f'{metric}_min'] = df.groupby(by=['timestamp'])[metric].min().reset_index()[metric]
-                ret[f'{metric}_mean'] = df.groupby(by=['timestamp'])[metric].mean().reset_index()[metric]
-                ret[f'{metric}_max'] = df.groupby(by=['timestamp'])[metric].max().reset_index()[metric]
+                ret[f'{metric}_min'] = _min[metric]
+                ret[f'{metric}_mean'] = _mean[metric]
+                ret[f'{metric}_max'] = _max[metric]
             return ret
         except Exception as e:
             a, b, c = sys.exc_info()


### PR DESCRIPTION
compMinMeanMax returned 3 time series: `metric_min`, `metric_mean`, and `metric_max`. The analysis module returned identical time series. In other words, `metric_min`, `metric_mean` and `metric_max` looked exactly the same. The bug was caused by miscalculation in timestamp truncation calculation. The timestamp was truncated to the milliseconds, and it is very rare for the metrics across components to share the same milliseconds.

This patch truncate the timestamp to "seconds", so that the metrics in the same second can be grouped and calculate min/mean/max. It is converted to "milliseconds" after the truncation since Grafana expected the millisecond since Epoch.